### PR TITLE
Update project references

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
+++ b/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
@@ -48,9 +48,9 @@
     <EmbeddedResource Include="Resources\IconSmall.png" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Archipelago.MultiClient.Net">
-      <HintPath>$(HollowKnightRefs)/Mods/Archipelago.HollowKnight/Archipelago.MultiClient.Net.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll</HintPath>
     </Reference>
@@ -86,9 +86,6 @@
     </Reference>
     <Reference Include="netstandard">
       <HintPath>$(HollowKnightRefs)/netstandard.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>$(HollowKnightRefs)/Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
       <HintPath>$(HollowKnightRefs)/PlayMaker.dll</HintPath>
@@ -320,9 +317,6 @@
     </Reference>
     <Reference Include="UnityEngine.XRModule">
       <HintPath>$(HollowKnightRefs)/UnityEngine.XRModule.dll</HintPath>
-    </Reference>
-    <Reference Include="websocket-sharp">
-      <HintPath>$(HollowKnightRefs)/Mods/Archipelago.HollowKnight/websocket-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
+++ b/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
@@ -12,7 +12,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <LangVersion>latest</LangVersion>
     <!-- Change this to the path of your modded HK installation -->
-    <HollowKnightRefs>D:\SteamLibrary\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
+    <HollowKnightRefs>C:\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
     <!-- Change this to the path where you want the ready-to-upload exports to be -->
     <ExportDir>..\..\Exports</ExportDir>
   </PropertyGroup>
@@ -49,52 +49,52 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Archipelago.MultiClient.Net">
-      <HintPath>..\DLLs\Archipelago.MultiClient.Net.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mods/Archipelago.HollowKnight/Archipelago.MultiClient.Net.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\DLLs\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\DLLs\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="GalaxyCSharp">
-      <HintPath>..\DLLs\GalaxyCSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/GalaxyCSharp.dll</HintPath>
     </Reference>
     <Reference Include="ItemChanger">
-      <HintPath>..\DLLs\ItemChanger.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mods/ItemChanger/ItemChanger.dll</HintPath>
     </Reference>
     <Reference Include="MenuChanger">
-      <HintPath>..\DLLs\MenuChanger.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mods/MenuChanger/MenuChanger.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>..\DLLs\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_PlayMaker">
-      <HintPath>..\DLLs\MMHOOK_PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MMHOOK_PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
-      <HintPath>..\DLLs\Mono.Cecil.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Security">
-      <HintPath>..\DLLs\Mono.Security.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mono.Security.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour">
-      <HintPath>..\DLLs\MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>..\DLLs\MonoMod.Utils.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="netstandard">
       <HintPath>$(HollowKnightRefs)/netstandard.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\DLLs\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>..\DLLs\PlayMaker.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="RecentItemsDisplay">
-      <HintPath>..\DLLs\RecentItemsDisplay.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mods/RecentItemsDisplay/RecentItemsDisplay.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition">
       <HintPath>..\DLLs\System.ComponentModel.Composition.dll</HintPath>
@@ -114,9 +114,6 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization.Xml" />
-    <Reference Include="System.ServiceModel.Internals">
-      <HintPath>..\DLLs\System.ServiceModel.Internals.dll</HintPath>
-    </Reference>
     <Reference Include="System.Transactions">
       <HintPath>..\DLLs\System.Transactions.dll</HintPath>
     </Reference>
@@ -124,208 +121,208 @@
       <HintPath>..\DLLs\System.Xml.XPath.XDocument.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Timeline">
-      <HintPath>..\DLLs\Unity.Timeline.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Unity.Timeline.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\DLLs\UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AccessibilityModule">
-      <HintPath>..\DLLs\UnityEngine.AccessibilityModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AccessibilityModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AIModule">
-      <HintPath>..\DLLs\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AndroidJNIModule">
-      <HintPath>..\DLLs\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AndroidJNIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\DLLs\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ARModule">
-      <HintPath>..\DLLs\UnityEngine.ARModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ARModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\DLLs\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\DLLs\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClothModule">
-      <HintPath>..\DLLs\UnityEngine.ClothModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ClothModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClusterInputModule">
-      <HintPath>..\DLLs\UnityEngine.ClusterInputModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ClusterInputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ClusterRendererModule">
-      <HintPath>..\DLLs\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ClusterRendererModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\DLLs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CrashReportingModule">
-      <HintPath>..\DLLs\UnityEngine.CrashReportingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.CrashReportingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.DirectorModule">
-      <HintPath>..\DLLs\UnityEngine.DirectorModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.DirectorModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.DSPGraphModule">
-      <HintPath>..\DLLs\UnityEngine.DSPGraphModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.DSPGraphModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GameCenterModule">
-      <HintPath>..\DLLs\UnityEngine.GameCenterModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.GameCenterModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GIModule">
-      <HintPath>..\DLLs\UnityEngine.GIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.GIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.GridModule">
-      <HintPath>..\DLLs\UnityEngine.GridModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.GridModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.HotReloadModule">
-      <HintPath>..\DLLs\UnityEngine.HotReloadModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.HotReloadModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\DLLs\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ImageConversionModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\DLLs\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\DLLs\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\DLLs\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.InputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule">
-      <HintPath>..\DLLs\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.LocalizationModule">
-      <HintPath>..\DLLs\UnityEngine.LocalizationModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.LocalizationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\DLLs\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PerformanceReportingModule">
-      <HintPath>..\DLLs\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.PerformanceReportingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule">
-      <HintPath>..\DLLs\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.Physics2DModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\DLLs\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ProfilerModule">
-      <HintPath>..\DLLs\UnityEngine.ProfilerModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ProfilerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule">
-      <HintPath>..\DLLs\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule">
-      <HintPath>..\DLLs\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.ScreenCaptureModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule">
-      <HintPath>..\DLLs\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.SharedInternalsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule">
-      <HintPath>..\DLLs\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.SpriteMaskModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SpriteShapeModule">
-      <HintPath>..\DLLs\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.SpriteShapeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.StreamingModule">
-      <HintPath>..\DLLs\UnityEngine.StreamingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.StreamingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SubstanceModule">
-      <HintPath>..\DLLs\UnityEngine.SubstanceModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.SubstanceModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.SubsystemsModule">
-      <HintPath>..\DLLs\UnityEngine.SubsystemsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.SubsystemsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
-      <HintPath>..\DLLs\UnityEngine.TerrainModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TerrainModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TerrainPhysicsModule">
-      <HintPath>..\DLLs\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TerrainPhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>..\DLLs\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TextCoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\DLLs\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TilemapModule">
-      <HintPath>..\DLLs\UnityEngine.TilemapModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TilemapModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TLSModule">
-      <HintPath>..\DLLs\UnityEngine.TLSModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.TLSModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\DLLs\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>..\DLLs\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UIElementsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsNativeModule">
-      <HintPath>..\DLLs\UnityEngine.UIElementsNativeModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UIElementsNativeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\DLLs\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UmbraModule">
-      <HintPath>..\DLLs\UnityEngine.UmbraModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UmbraModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UNETModule">
-      <HintPath>..\DLLs\UnityEngine.UNETModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UNETModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule">
-      <HintPath>..\DLLs\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityAnalyticsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityConnectModule">
-      <HintPath>..\DLLs\UnityEngine.UnityConnectModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityConnectModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityCurlModule">
-      <HintPath>..\DLLs\UnityEngine.UnityCurlModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityCurlModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule">
-      <HintPath>..\DLLs\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityTestProtocolModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule">
-      <HintPath>..\DLLs\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule">
-      <HintPath>..\DLLs\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule">
-      <HintPath>..\DLLs\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule">
-      <HintPath>..\DLLs\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\DLLs\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VehiclesModule">
-      <HintPath>..\DLLs\UnityEngine.VehiclesModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.VehiclesModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VFXModule">
-      <HintPath>..\DLLs\UnityEngine.VFXModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.VFXModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VideoModule">
-      <HintPath>..\DLLs\UnityEngine.VideoModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.VideoModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VirtualTexturingModule">
-      <HintPath>..\DLLs\UnityEngine.VirtualTexturingModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.VirtualTexturingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VRModule">
-      <HintPath>..\DLLs\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.VRModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.WindModule">
-      <HintPath>..\DLLs\UnityEngine.WindModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.WindModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.XRModule">
-      <HintPath>..\DLLs\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/UnityEngine.XRModule.dll</HintPath>
     </Reference>
     <Reference Include="websocket-sharp">
-      <HintPath>..\DLLs\websocket-sharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/Mods/Archipelago.HollowKnight/websocket-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
+++ b/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
@@ -94,28 +94,28 @@
       <HintPath>$(HollowKnightRefs)/Mods/RecentItemsDisplay/RecentItemsDisplay.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition">
-      <HintPath>..\DLLs\System.ComponentModel.Composition.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.ComponentModel.Composition.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration">
-      <HintPath>..\DLLs\System.Configuration.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.StackTrace">
-      <HintPath>..\DLLs\System.Diagnostics.StackTrace.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.Diagnostics.StackTrace.dll</HintPath>
     </Reference>
     <Reference Include="System.EnterpriseServices">
-      <HintPath>..\DLLs\System.EnterpriseServices.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.EnterpriseServices.dll</HintPath>
     </Reference>
     <Reference Include="System.Globalization.Extensions">
-      <HintPath>..\DLLs\System.Globalization.Extensions.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.Globalization.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization.Xml" />
     <Reference Include="System.Transactions">
-      <HintPath>..\DLLs\System.Transactions.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.Transactions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.XPath.XDocument">
-      <HintPath>..\DLLs\System.Xml.XPath.XDocument.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)/System.Xml.XPath.XDocument.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Timeline">
       <HintPath>$(HollowKnightRefs)/Unity.Timeline.dll</HintPath>


### PR DESCRIPTION
- Update assemblies to generally be relative to the HK install path.
- Remove System.ServiceModel.Internals, which I couldn't find and didn't
  appear to affect the mod.
  
Realized I accidentally changed the HollowKnightRefs folder as I created this PR.  Oops.  Everyone is going to need to tailor it to their own system anyways.