### PR TITLE
Feature/better item display

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -230,12 +230,24 @@ namespace Archipelago.HollowKnight
             session.Locations.ScoutLocationsAsync(ScoutCallback, locations.ToArray());
         }
 
+        internal void SetItemTags(AbstractItem item, string name, string slotName)
+        {
+            var tag = item.AddTag<InteropTag>();
+            tag.Message = "RecentItems";
+            tag.Properties["DisplayMessage"] = $"{name}\nsent to {slotName}.";
+        }
+
         public void PlaceItem(string location, string name, NetworkItem netItem)
         {
             LogDebug($"[PlaceItem] Placing item {name} into {location} with ID {netItem.Item}");
             var originalLocation = string.Copy(location);
             location = StripShopSuffix(location);
             AbstractLocation loc = Finder.GetLocation(location);
+            string targetSlotName = null;
+            if (netItem.Player != slot)
+            {
+                targetSlotName = session.Players.GetPlayerName(netItem.Player);
+            }
 
             if (loc == null)
             {
@@ -251,34 +263,33 @@ namespace Archipelago.HollowKnight
             {
                 // Since HK is a remote items game, I don't want the placement to actually do anything. The item will come from the server.
                 var originalItem = Finder.GetItem(name);
-                item = new DisguisedVoidItem(originalItem);
+                item = new DisguisedVoidItem(originalItem, targetSlotName);
 
-                item.ModifyItem += (x) =>
+                if (netItem.Player == slot)
                 {
-                    try
+                    item.ModifyItem += (x) =>
                     {
-                        x.Info.MessageType = MessageType.None;
-                    }
-                    catch { }
-                };
+                        try
+                        {
+                            x.Info.MessageType = MessageType.None;
+                        }
+                        catch { }
+                    };
 
-                var tag = item.AddTag<InteropTag>();
-                tag.Message = "RecentItems";
-
-                if (netItem.Player != slot)
-                {
-                    var receivingPlayer = session.Players.GetPlayerName(netItem.Player);
-                    tag.Properties["DisplayMessage"] = $"{item.UIDef.GetPreviewName()}\nsent to {receivingPlayer}.";
+                    var tag = item.AddTag<InteropTag>();
+                    tag.Message = "RecentItems";
+                    tag.Properties["IgnoreItem"] = true;
                 }
                 else
                 {
-                    tag.Properties["IgnoreItem"] = true;
+                    SetItemTags(item, originalItem.GetPreviewName(), targetSlotName);
                 }
             }
             else
             {
                 // If item doesn't belong to Hollow Knight, then it is a remote item for another game.
-                item = new ArchipelagoItem(name);
+                item = new ArchipelagoItem(name, targetSlotName, netItem.Flags);
+                SetItemTags(item, name, targetSlotName);
             }
 
             item.OnGive += (x) =>
@@ -286,21 +297,21 @@ namespace Archipelago.HollowKnight
                 var id = session.Locations.GetLocationIdFromName("Hollow Knight", originalLocation);
                 session.Locations.CompleteLocationChecks(id);
             };
-            var targetSlotName = session.Players.GetPlayerName(netItem.Player);
+            targetSlotName = session.Players.GetPlayerName(netItem.Player);
             if (SpecialPlacementHandler.IsShopPlacement(location) || SpecialPlacementHandler.IsSalubraPlacement(location) && !originalLocation.Contains("Requires_Charms"))
             {
                 LogDebug($"[PlaceItem] Detected shop placement for location: {location}");
-                SpecialPlacementHandler.PlaceShopItem(pmt, item, targetSlotName);
+                SpecialPlacementHandler.PlaceShopItem(pmt, item);
             }
             else if (SpecialPlacementHandler.IsSalubraCharmShopPlacement(originalLocation))
             {
                 LogDebug($"[PlaceItem] Detected Salubra charm shop placement for location: {location}");
-                SpecialPlacementHandler.PlaceSalubraCharmShop(originalLocation, pmt, item, targetSlotName);
+                SpecialPlacementHandler.PlaceSalubraCharmShop(originalLocation, pmt, item);
             }
             else if (SpecialPlacementHandler.IsSeerPlacement(location))
             {
                 LogDebug($"[PlaceItem] Detected seer placement for location: {location}.");
-                SpecialPlacementHandler.PlaceSeerItem(originalLocation, pmt, item, targetSlotName);
+                SpecialPlacementHandler.PlaceSeerItem(originalLocation, pmt, item);
             }
             else if (SpecialPlacementHandler.IsEggShopPlacement(location))
             {
@@ -310,7 +321,7 @@ namespace Archipelago.HollowKnight
             else if (SpecialPlacementHandler.IsGrubfatherPlacement(location))
             {
                 LogDebug($"[PlaceItem] Detected Grubfather placement for original location: {originalLocation}. Trimmed location: {location}");
-                SpecialPlacementHandler.PlaceGrubfatherItem(originalLocation, pmt, item, targetSlotName);
+                SpecialPlacementHandler.PlaceGrubfatherItem(originalLocation, pmt, item);
             }
             else
             {

--- a/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
@@ -1,4 +1,5 @@
-﻿using ItemChanger;
+﻿using Archipelago.MultiClient.Net.Enums;
+using ItemChanger;
 using ItemChanger.Tags;
 using ItemChanger.UIDefs;
 
@@ -6,19 +7,36 @@ namespace Archipelago.HollowKnight.IC
 {
     public class ArchipelagoItem : AbstractItem
     {
-        public ArchipelagoItem(string name)
+        public ArchipelagoItem(string name, string targetSlotName = null, ItemFlags itemFlags = 0)
         {
+            string desc;
+            if (itemFlags.HasFlag(ItemFlags.Advancement))
+            {
+                desc = "This otherworldly artifact looks very important. Somebody probably really needs it.";
+            }
+            else if (itemFlags.HasFlag(ItemFlags.NeverExclude))
+            {
+                desc = "This otherworldly artifact looks like it might be useful to someone.";
+            }
+            else
+            {
+                desc = "I'm not entirely sure what this is. It appears to be a strange artifact from another world.";
+            }
+            if (itemFlags.HasFlag(ItemFlags.Trap))
+            {
+                desc += " Seems kinda suspicious though. It might be full of bees.";
+            }
             this.name = name;
+            if(targetSlotName != null)
+            {
+                name = $"{targetSlotName}'s {name}";
+            }
             UIDef = new ArchipelagoUIDef(new MsgUIDef
             {
-                name = new BoxedString(this.name),
-                shopDesc = new BoxedString("This looks important, assuming beating the game is important to you."),
+                name = new BoxedString(name),
+                shopDesc = new BoxedString(desc),
                 sprite = new BoxedSprite(Archipelago.SmallSprite)
             });
-
-            InteropTag tag = AddTag<InteropTag>();
-            tag.Message = "RecentItems";
-            tag.Properties["DisplayMessage"] = $"{this.name}\nsent to the multiworld.";
         }
 
         // INFO: this can be used to restore placements from save

--- a/Archipelago.HollowKnight/IC/ArchipelagoUIDef.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoUIDef.cs
@@ -5,19 +5,25 @@ namespace Archipelago.HollowKnight.IC
 {
     internal class ArchipelagoUIDef : MsgUIDef
     {
-        public ArchipelagoUIDef(UIDef def)
+        public ArchipelagoUIDef(UIDef def, string targetSlotName = null)
         {
             if (def is MsgUIDef msgDef)
             {
-                name = msgDef.name.Clone();
                 shopDesc = msgDef.shopDesc.Clone();
                 sprite = msgDef.sprite.Clone();
             }
             else
             {
-                name = new BoxedString(def.GetPreviewName());
                 shopDesc = new BoxedString(def.GetShopDesc());
                 sprite = new EmptySprite();
+            }
+            if (targetSlotName == null)
+            {
+                name = new BoxedString(def.GetPreviewName());
+            }
+            else
+            {
+                name = new BoxedString($"{targetSlotName}'s {def.GetPreviewName()}");
             }
         }
     }

--- a/Archipelago.HollowKnight/IC/DisguisedVoidItem.cs
+++ b/Archipelago.HollowKnight/IC/DisguisedVoidItem.cs
@@ -5,10 +5,21 @@ namespace Archipelago.HollowKnight.IC
 {
     internal class DisguisedVoidItem : AbstractItem
     {
-        public DisguisedVoidItem(AbstractItem originalItem)
+        public DisguisedVoidItem(AbstractItem originalItem, string targetSlotName = null)
         {
             name = originalItem.name;
-            UIDef = new ArchipelagoUIDef(originalItem.UIDef);
+            UIDef = new ArchipelagoUIDef(originalItem.UIDef, targetSlotName);
+
+            InteropTag tag = AddTag<InteropTag>();
+            tag.Message = "RecentItems";
+            if (targetSlotName != null)
+            {
+                tag.Properties["DisplayMessage"] = $"{originalItem.GetPreviewName()}\nsent to {targetSlotName}.";
+            }
+            else
+            {
+                tag.Properties["DisplayMessage"] = $"{originalItem.GetPreviewName()}\nsent to the multiworld.";
+            }
         }
 
         public override void GiveImmediate(GiveInfo info)

--- a/Archipelago.HollowKnight/IC/SpecialPlacementHandler.cs
+++ b/Archipelago.HollowKnight/IC/SpecialPlacementHandler.cs
@@ -47,7 +47,7 @@ namespace Archipelago.HollowKnight.IC
             return location.StartsWith("Salubra_(Requires_Charms)");
         }
 
-        public static void PlaceGrubfatherItem(string originalLocation, AbstractPlacement pmt, AbstractItem item, string targetSlotName)
+        public static void PlaceGrubfatherItem(string originalLocation, AbstractPlacement pmt, AbstractItem item)
         {
             var costChestPlacement = pmt as CostChestPlacement;
             if (!costChestPlacement.HasTag<DestroyGrubRewardTag>())
@@ -55,8 +55,6 @@ namespace Archipelago.HollowKnight.IC
                 var tag = costChestPlacement.AddTag<DestroyGrubRewardTag>();
                 tag.destroyRewards = GrubfatherRewards.AllNonGeo;
             }
-            SetUIDefToContainTargetSlotName(item, targetSlotName);
-
             costChestPlacement.AddItem(item, Cost.NewGrubCost(GetGrubCostForLocation(originalLocation)));
         }
 
@@ -95,7 +93,7 @@ namespace Archipelago.HollowKnight.IC
             }
         }
 
-        public static void PlaceSeerItem(string originalLocation, AbstractPlacement pmt, AbstractItem item, string targetSlotName)
+        public static void PlaceSeerItem(string originalLocation, AbstractPlacement pmt, AbstractItem item)
         {
             var costChestPlacement = pmt as CostChestPlacement;
             if (!costChestPlacement.HasTag<DestroySeerRewardTag>())
@@ -103,7 +101,6 @@ namespace Archipelago.HollowKnight.IC
                 var tag = costChestPlacement.AddTag<DestroySeerRewardTag>();
                 tag.destroyRewards = SeerRewards.All & ~SeerRewards.GladeDoor & ~SeerRewards.Ascension;
             }
-            SetUIDefToContainTargetSlotName(item, targetSlotName);
             costChestPlacement.AddItem(item, Cost.NewEssenceCost(GetEssenceCostForLocation(originalLocation)));
         }
 
@@ -120,43 +117,15 @@ namespace Archipelago.HollowKnight.IC
             }
         }
 
-        public static void PlaceShopItem(AbstractPlacement pmt, AbstractItem item, string targetSlotName)
+        public static void PlaceShopItem(AbstractPlacement pmt, AbstractItem item)
         {
             var shopPlacement = pmt as ShopPlacement;
-            SetUIDefToContainTargetSlotName(item, targetSlotName);
             shopPlacement.AddItemWithCost(item, GenerateGeoCost());
         }
 
-        private static void SetUIDefToContainTargetSlotName(AbstractItem item, string targetSlotName)
-        {
-            var name = new BoxedString($"{item.GetPreviewName()} (for {targetSlotName})");
-            item.UIDef = new MsgUIDef()
-            {
-                name = name,
-                shopDesc = new BoxedString(item.UIDef.GetShopDesc()),
-                sprite = item.UIDef switch
-                {
-                    MsgUIDef def => def.sprite.Clone(),
-                    _ => new EmptySprite()
-                }
-            };
-        }
-
-        public static void PlaceSalubraCharmShop(string originalLocation, AbstractPlacement pmt, AbstractItem item, string targetSlotName)
+        public static void PlaceSalubraCharmShop(string originalLocation, AbstractPlacement pmt, AbstractItem item)
         {
             var shopPlacement = pmt as ShopPlacement;
-            var name = new BoxedString($"{item.GetPreviewName()} (for {targetSlotName})");
-            item.UIDef = new MsgUIDef()
-            {
-                name = name,
-                shopDesc = new BoxedString(item.UIDef.GetShopDesc()),
-                sprite = item.UIDef switch
-                {
-                    MsgUIDef def => def.sprite.Clone(),
-                    _ => new EmptySprite()
-                }
-            };
-
             var charmCostAmount = GetCharmCostForLocation(originalLocation);
             var charmCost = new PDIntCost(charmCostAmount, nameof(PlayerData.charmsOwned), $"Acquire {charmCostAmount} total charms to buy this item.");
             var cost = new MultiCost(GenerateGeoCost(), charmCost);


### PR DESCRIPTION
Redo of #41, targeting the correct branch.  Original text included below:

Closes #8, #13, #14

Names for non-self items are now set as "Slotname's Item". This fixes
all issues with previews e.g. on Dream Trees, Grubs, Shops, etc.
Overrides for RecentItems are constructed before this rename, so those
still follow the `"Item\nsent to Slotname"` format.

Non-HK items in shops now show an appropriate description based on
advancement/useful/junk/trap status. Possible TODO: Pick a random item
name and name these as `"Playername's Mantis Claw?"` in shops, akin to OOT

Bottom text is no longer suppressed for HK items that aren't the local
player's. It continues to be suppressed for the local player's items
since they'll get it from the server anyways.