### PR TITLE
Allow configurable goals

### DIFF
--- a/Archipelago.HollowKnight/SlotData/SlotOptions.cs
+++ b/Archipelago.HollowKnight/SlotData/SlotOptions.cs
@@ -165,5 +165,8 @@ namespace Archipelago.HollowKnight.SlotData
 
         [JsonProperty("EggShopSlots")]
         public int EggShopSlots { get; set; }
+
+        [JsonProperty("ArchipelagoGoal")]
+        public Archipelago.Goal Goal { get; set; }
     }
 }


### PR DESCRIPTION
Work in progress on configurable goals.  This still needs changes on the AP side, as well as testing to make sure goals actually trigger correctly.  Would close #48 

- Allows a goal to be provided in SlotOptions. 
- Changes the check for victory to be upon loading the ending cinematic rather than waiting for the end completion scene.
- Shows the current goal at the THK waterfall statue in City of Tears.

AP servers that do not set the Goal enum will default the goal to "Any".