### PR TITLE
Save connection details as GlobalSettings

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -22,7 +22,7 @@ using UnityEngine;
 
 namespace Archipelago.HollowKnight
 {
-    public class Archipelago : Mod, ILocalSettings<ConnectionDetails>
+    public class Archipelago : Mod, IGlobalSettings<ConnectionDetails>, ILocalSettings<ConnectionDetails>
     {
         private readonly Version ArchipelagoProtocolVersion = new Version(0, 3, 0);
 
@@ -58,7 +58,6 @@ namespace Archipelago.HollowKnight
         {
             base.Initialize();
             Log("Initializing");
-
             Instance = this;
             spriteManager = new SpriteManager(typeof(Archipelago).Assembly, "Archipelago.HollowKnight.Resources.");
             Sprite = spriteManager.GetSprite("Icon");
@@ -466,12 +465,32 @@ namespace Archipelago.HollowKnight
 
         public void OnLoadLocal(ConnectionDetails details)
         {
+            if(details.SlotName == null || details.SlotName == "")  // Apparently, this is called even before a save is loaded.  Catch this.
+            {
+                return;
+            }
             ApSettings = details;
         }
 
         public ConnectionDetails OnSaveLocal()
         {
             return ApSettings;
+        }
+
+        public void OnLoadGlobal(ConnectionDetails details)
+        {
+            ApSettings = details;
+            ApSettings.ItemIndex = 0;
+        }
+
+        public ConnectionDetails OnSaveGlobal()
+        {
+            return new ConnectionDetails()
+            {
+                ServerUrl = ApSettings.ServerUrl,
+                ServerPort = ApSettings.ServerPort,
+                SlotName = ApSettings.SlotName
+            };
         }
     }
 }


### PR DESCRIPTION
Server URL, Server Port, and SlotName will be saved as GlobalSettings.

Also adjusts OnLoadLocal to noop if SlotName is empty.  For a real save,
this will never be the case -- but apparently OnLoadLocal is also called
for the menu and in other cases which was causing the restored global
settings to be consistently overridden with their defaults.

Compatible with #60, but does not require it.  Related issue #45