### PR TITLE
Properly set default shop items (Iselda Pins/Markers, Leg Eater repairs)

### DIFF
--- a/Archipelago.HollowKnight/Placements/ShopPlacementHandler.cs
+++ b/Archipelago.HollowKnight/Placements/ShopPlacementHandler.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using ItemChanger;
 using ItemChanger.Placements;
-
 namespace Archipelago.HollowKnight.Placements
 {
     internal class ShopPlacementHandler : IPlacementHandler
@@ -20,6 +19,57 @@ namespace Archipelago.HollowKnight.Placements
         {
             var shopPlacement = pmt as ShopPlacement;
             shopPlacement.AddItemWithCost(item, Costs.GenerateGeoCost());
+            shopPlacement.defaultShopItems = this.GetDefaultShopItems();
+        }
+
+        public DefaultShopItems GetDefaultShopItems()
+        {
+            var options = Archipelago.Instance.SlotOptions;
+            DefaultShopItems items = DefaultShopItems.IseldaMapPins | DefaultShopItems.IseldaMapMarkers | DefaultShopItems.LegEaterRepair;
+
+            // Uncomment these if/when we stop sending vanilla placements from AP
+            /*
+            if(!options.RandomizeKeys)
+            {
+                items |= DefaultShopItems.SlyLantern;
+                items |= DefaultShopItems.SlySimpleKey;
+                items |= DefaultShopItems.SlyKeyElegantKey;
+            }
+
+            if (!options.RandomizeCharms)
+            {
+                items |= DefaultShopItems.SlyCharms;
+                items |= DefaultShopItems.SlyKeyCharms;
+                items |= DefaultShopItems.IseldaCharms;
+                items |= DefaultShopItems.SalubraCharms;
+                items |= DefaultShopItems.LegEaterCharms;
+            }
+
+            if (!options.RandomizeMaps)
+            {
+                items |= DefaultShopItems.IseldaQuill;
+                items |= DefaultShopItems.IseldaMaps;
+            }
+
+            if (!options.RandomizeMaskShards)
+            {
+                items |= DefaultShopItems.SlyMaskShards;
+            }
+
+            if (!options.RandomizeVesselFragments)
+            {
+                items |= DefaultShopItems.SlyVesselFragments;
+            }
+
+            if (!options.RandomizeRancidEggs)
+            {
+                items |= DefaultShopItems.SlyRancidEgg;
+            }
+
+            // FIXME: Salubra charm notches.
+            // Ref: https://github.com/homothetyhk/RandomizerMod/blob/39c6feeb7a4c8c94eef62481dec8864027110ec4/RandomizerMod/IC/Shops.cs#L58
+            */
+            return items;
         }
     }
 }


### PR DESCRIPTION
This solves Leg Eater being unable to repair charms (Closes #26), as well as restoring Map Pins and Map Markers to Iselda's shop (sometimes a required objective in Bingosync)

Framework for restoring other shops to vanilla is included for once we stop placing default items AP-side, but is commented out for now. 