### PR TITLE
Maintain some default shop items

### DIFF
--- a/Archipelago.HollowKnight/Placements/ShopPlacementHandler.cs
+++ b/Archipelago.HollowKnight/Placements/ShopPlacementHandler.cs
@@ -20,6 +20,7 @@ namespace Archipelago.HollowKnight.Placements
         {
             var shopPlacement = pmt as ShopPlacement;
             shopPlacement.AddItemWithCost(item, Costs.GenerateGeoCost());
+            shopPlacement.defaultShopItems = DefaultShopItems.IseldaMapPins | DefaultShopItems.IseldaMapMarkers | DefaultShopItems.LegEaterRepair;
         }
     }
 }


### PR DESCRIPTION
When adding shop placements, set the appropriate flags for default shop items:

- Leg Eater Repair (required for Divine)
- Iselda Map Pins/Map Markers (required for some Bingosync objectives)

Realistically, we could put the latter as junk in the pool at some point.

Addresses the issues in the previous PR.  Closes #26 