### PR TITLE
Redo of customized goals

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -121,11 +121,14 @@ namespace Archipelago.HollowKnight
 
             ConnectToArchipelago();
 
-            goal = Goal.GetGoal(SlotOptions.Goal);
-            if (goal == null)
+            try
             {
-                LogError($"Listed goal is {SlotOptions.Goal}, which is greater than {Goals.MAX}.  Is this an outdated client?");
-                throw new Exception("Unrecognized goal condition (are you running an outdated client?)");
+                goal = Goal.GetGoal(SlotOptions.Goal);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                LogError($"Listed goal is {SlotOptions.Goal}, which is greater than {GoalsLookup.MAX}.  Is this an outdated client?");
+                throw ex;
             }
             goal.Select();
 

--- a/Archipelago.HollowKnight/Goals.cs
+++ b/Archipelago.HollowKnight/Goals.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.SceneManagement;
+using ItemChanger;
+
+namespace Archipelago.HollowKnight
+{
+    public enum Goals
+    {
+        Any = 0,
+        HollowKnight = 1,
+        SealedSiblings = 2,
+        Radiance = 3,
+        Godhome = 4,
+        MAX = Godhome
+    }
+
+    abstract class Goal {
+        private static readonly Dictionary<Goals, Goal> Lookup = new Dictionary<Goals, Goal>()
+        {
+            [Goals.Any] = new AnyGoal(),
+            [Goals.HollowKnight] = new HollowKnightGoal(),
+            [Goals.SealedSiblings] = new SealedSiblingsGoal(),
+            [Goals.Radiance] = new RadianceGoal(),
+            [Goals.Godhome] = new GodhomeGoal()
+        };
+
+        public static Goal GetGoal(Goals key)
+        {
+            Goal value;
+            if (Lookup.TryGetValue(key, out value))
+            {
+                return value;
+            }
+            return null;
+        }
+
+        public abstract string Name { get; }
+        public abstract string Description { get; }
+
+        public abstract bool VictoryCondition(string sceneName);
+        public void CheckForVictory(Scene scene)
+        {
+            Archipelago.Instance.LogDebug($"Checking for victory; goal is {this.Name}; scene {scene.name}");
+            if (VictoryCondition(scene.name))
+            {
+                Archipelago.Instance.LogDebug($"Victory detected, declaring!");
+                Archipelago.Instance.DeclareVictory();
+            }
+        }
+
+        public void Select()
+        {
+            ItemChanger.Events.AddLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_TOP"), FountainPlaqueTopEdit);
+            ItemChanger.Events.AddLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_MAIN"), FountainPlaqueNameEdit);
+            ItemChanger.Events.AddLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_DESC"), FountainPlaqueDescEdit);
+            ItemChanger.Events.OnSceneChange += CheckForVictory;
+        }
+
+        public void Unselect()
+        {
+            {
+                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_TOP"), FountainPlaqueTopEdit);
+                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_MAIN"), FountainPlaqueNameEdit);
+                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_DESC"), FountainPlaqueDescEdit);
+                ItemChanger.Events.OnSceneChange -= CheckForVictory;
+            }
+        }
+        public void FountainPlaqueTopEdit(ref string s) { s = "Your goal is"; }
+        public void FountainPlaqueNameEdit(ref string s) { s = Name; }
+        public void FountainPlaqueDescEdit(ref string s) { s = Description; }
+
+        // Helpers for subclasses.
+        protected bool AcquiredVoidHeart
+        {
+            get { return PlayerData.instance.GetInt(nameof(PlayerData.royalCharmState)) == 4; }
+        }
+
+        protected bool EquippedVoidHeart
+        {
+            get { return AcquiredVoidHeart && PlayerData.instance.GetBool(nameof(PlayerData.equippedCharm_36)); }
+        }
+
+        protected bool HasThreeDreamers
+        {
+            get { return PlayerData.instance.GetInt(nameof(PlayerData.guardiansDefeated)) >= 3; }
+
+        }
+    }
+
+    class AnyGoal : Goal
+    {
+        public override string Name => "Beat the Game";
+        public override string Description => "Complete Hollow Knight with any ending.";
+
+        public override bool VictoryCondition(string sceneName)
+        {
+            return (
+                sceneName == SceneNames.Cinematic_Ending_A       // THK
+                || sceneName == SceneNames.Cinematic_Ending_B    // Sealed Siblings
+                || sceneName == SceneNames.Cinematic_Ending_C    // Radiance
+                || sceneName == "Cinematic_Ending_D"             // Godhome no flower quest(?)
+                || sceneName == SceneNames.Cinematic_Ending_E    // Godhome w/ flower quest
+            );
+        }
+    }
+
+    class HollowKnightGoal : Goal
+    {
+        public override string Name => "The Hollow Knight";
+        public override string Description => "Defeat The Hollow Knight<br>or any other ending with 3 dreamers.";
+
+        public override bool VictoryCondition(string sceneName)
+        {
+            return HasThreeDreamers && (
+                sceneName == SceneNames.Cinematic_Ending_A       // THK
+                || sceneName == SceneNames.Cinematic_Ending_B    // Sealed Siblings
+                || sceneName == SceneNames.Cinematic_Ending_C    // Radiance
+                || sceneName == "Cinematic_Ending_D"             // Godhome no flower quest(?)
+                || sceneName == SceneNames.Cinematic_Ending_E    // Godhome
+            );
+        }
+    }
+
+    class SealedSiblingsGoal : Goal
+    {
+        public override string Name => "Sealed Siblings";
+        public override string Description => "Complete the Sealed Siblings ending<br>or any other ending with 3 dreamers and Void Heart equipped.";
+
+        public override bool VictoryCondition(string sceneName)
+        {
+            return HasThreeDreamers && EquippedVoidHeart && (
+                sceneName == SceneNames.Cinematic_Ending_B       // Sealed Siblings
+                || sceneName == SceneNames.Cinematic_Ending_C    // Radiance
+                || sceneName == "Cinematic_Ending_D"             // Godhome no flower quest(?)
+                || sceneName == SceneNames.Cinematic_Ending_E    // Godhome
+            );
+        }
+    }
+
+    class RadianceGoal : Goal
+    {
+        public override string Name => "Dream No More";
+        public override string Description => "Defeat The Radiance or Absolute Radiance<br>after obtaining Void Heart and 3 dreamers.";
+
+        public override bool VictoryCondition(string sceneName)
+        {
+            return HasThreeDreamers && EquippedVoidHeart && (
+                sceneName == SceneNames.Cinematic_Ending_C       // Radiance
+                || sceneName == "Cinematic_Ending_D"             // Godhome no flower quest(?)
+                || sceneName == SceneNames.Cinematic_Ending_E    // Godhome
+            );
+        }
+    }
+
+    class GodhomeGoal : Goal
+    {
+        public override string Name => "Embrace the Void";
+        public override string Description => "Defeat Absolute Radiance<br>at the end of Pantheon 5.";
+
+        public override bool VictoryCondition(string sceneName)
+        {
+            return (
+                sceneName == "Cinematic_Ending_D"                // Godhome no flower quest(?)
+                || sceneName == SceneNames.Cinematic_Ending_E   // Godhome
+            );
+        }
+    }
+}

--- a/Archipelago.HollowKnight/Goals.cs
+++ b/Archipelago.HollowKnight/Goals.cs
@@ -8,7 +8,7 @@ using ItemChanger;
 
 namespace Archipelago.HollowKnight
 {
-    public enum Goals
+    public enum GoalsLookup
     {
         Any = 0,
         HollowKnight = 1,
@@ -19,23 +19,23 @@ namespace Archipelago.HollowKnight
     }
 
     abstract class Goal {
-        private static readonly Dictionary<Goals, Goal> Lookup = new Dictionary<Goals, Goal>()
+        private static readonly Dictionary<GoalsLookup, Goal> Lookup = new Dictionary<GoalsLookup, Goal>()
         {
-            [Goals.Any] = new AnyGoal(),
-            [Goals.HollowKnight] = new HollowKnightGoal(),
-            [Goals.SealedSiblings] = new SealedSiblingsGoal(),
-            [Goals.Radiance] = new RadianceGoal(),
-            [Goals.Godhome] = new GodhomeGoal()
+            [GoalsLookup.Any] = new AnyGoal(),
+            [GoalsLookup.HollowKnight] = new HollowKnightGoal(),
+            [GoalsLookup.SealedSiblings] = new SealedSiblingsGoal(),
+            [GoalsLookup.Radiance] = new RadianceGoal(),
+            [GoalsLookup.Godhome] = new GodhomeGoal()
         };
 
-        public static Goal GetGoal(Goals key)
+        public static Goal GetGoal(GoalsLookup key)
         {
             Goal value;
             if (Lookup.TryGetValue(key, out value))
             {
                 return value;
             }
-            return null;
+            throw new ArgumentOutOfRangeException($"Unrecognized goal condition {key} (are you running an outdated client?)");
         }
 
         public abstract string Name { get; }
@@ -62,16 +62,14 @@ namespace Archipelago.HollowKnight
 
         public void Unselect()
         {
-            {
-                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_TOP"), FountainPlaqueTopEdit);
-                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_MAIN"), FountainPlaqueNameEdit);
-                ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_DESC"), FountainPlaqueDescEdit);
-                ItemChanger.Events.OnSceneChange -= CheckForVictory;
-            }
+            ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_TOP"), FountainPlaqueTopEdit);
+            ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_MAIN"), FountainPlaqueNameEdit);
+            ItemChanger.Events.RemoveLanguageEdit(new ItemChanger.LanguageKey("Prompts", "FOUNTAIN_PLAQUE_DESC"), FountainPlaqueDescEdit);
+            ItemChanger.Events.OnSceneChange -= CheckForVictory;
         }
-        public void FountainPlaqueTopEdit(ref string s) { s = "Your goal is"; }
-        public void FountainPlaqueNameEdit(ref string s) { s = Name; }
-        public void FountainPlaqueDescEdit(ref string s) { s = Description; }
+        protected void FountainPlaqueTopEdit(ref string s) { s = "Your goal is"; }
+        protected void FountainPlaqueNameEdit(ref string s) { s = Name; }
+        protected void FountainPlaqueDescEdit(ref string s) { s = Description; }
 
         // Helpers for subclasses.
         protected bool AcquiredVoidHeart

--- a/Archipelago.HollowKnight/SlotData/SlotOptions.cs
+++ b/Archipelago.HollowKnight/SlotData/SlotOptions.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Archipelago.HollowKnight;
 
 namespace Archipelago.HollowKnight.SlotData
 {
@@ -165,5 +167,9 @@ namespace Archipelago.HollowKnight.SlotData
 
         [JsonProperty("EggShopSlots")]
         public int EggShopSlots { get; set; }
+
+        // Even though this is encoded as an int, it doesn't import properly without doing this.
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Goals Goal { get; set; }
     }
 }

--- a/Archipelago.HollowKnight/SlotData/SlotOptions.cs
+++ b/Archipelago.HollowKnight/SlotData/SlotOptions.cs
@@ -170,6 +170,6 @@ namespace Archipelago.HollowKnight.SlotData
 
         // Even though this is encoded as an int, it doesn't import properly without doing this.
         [JsonConverter(typeof(StringEnumConverter))]
-        public Goals Goal { get; set; }
+        public GoalsLookup Goal { get; set; }
     }
 }


### PR DESCRIPTION
Goals are now subclasses of Goal and each define their name, description,
and victory condition.  Like the previous implementation, the current goal
can be checked at the Hollow Knight statue in City of Tears -- this feels
analogous to about where in game progression one learns their goal in other
variable-goal randomizer games like Link to the Past and Ocarina of Time.

Supercedes #53 

Closes #48 