### PR TITLE
Rework the way connection details are tracked.

### DIFF
--- a/Archipelago.HollowKnight/ConnectionDetails.cs
+++ b/Archipelago.HollowKnight/ConnectionDetails.cs
@@ -2,8 +2,8 @@
 {
     public record ConnectionDetails
     {
-        public string ServerUrl { get; set; } = "archipelago.gg";
-        public int ServerPort { get; set; } = 38281;
+        public string ServerUrl { get; set; }
+        public int ServerPort { get; set; }
         public string SlotName { get; set; }
         public string ServerPassword { get; set; }
         public int ItemIndex { get; set; }

--- a/Archipelago.HollowKnight/MC/ArchipelagoModeMenuConstructor.cs
+++ b/Archipelago.HollowKnight/MC/ArchipelagoModeMenuConstructor.cs
@@ -19,7 +19,7 @@ namespace Archipelago.HollowKnight.MC
             
             ApPage = new MenuPage("Archipelago Settings", modeMenu);
             var settingsType = typeof(ConnectionDetails);
-            var settings = Archipelago.Instance.ApSettings;
+            var settings = Archipelago.Instance.MenuSettings;
 
             var urlField = new EntryField<string>(ApPage, "Server URL: ");
             urlField.InputField.characterLimit = 500;
@@ -77,6 +77,7 @@ namespace Archipelago.HollowKnight.MC
         private void StartNewGame()
         {
             Archipelago.Instance.ArchipelagoEnabled = true;
+            Archipelago.Instance.ApSettings = Archipelago.Instance.MenuSettings with {};  // Clone MenuSettings into ApSettings
             try
             {
                 // Archipelago.Instance.ConnectAndRandomize();


### PR DESCRIPTION
This separates out ApSettings (current save's connection details) from MenuSettings (preferences for the main menu screen) for sanity's sake.

Non-AP saves will always end up clearing out ApSettings and thus should never be mistaken as an AP save on load.

Fixes #75