### PR TITLE
Add IC modules for randomizer options.

### DIFF
--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -79,6 +79,37 @@ namespace Archipelago.HollowKnight
         {
             var session = Session;
             ItemChangerMod.CreateSettingsProfile();
+            // Add IC modules as needed
+            // FUTURE: If Entrance rando, disable palace midwarp and some logical blockers
+            // if (Entrance Rando Is Enabled) {
+            //     ItemChangerMod.Modules.Add<ItemChanger.Modules.DisablePalaceMidWarp>();
+            //     ItemChangerMod.Modules.Add<ItemChanger.Modules.RemoveInfectedBlockades>();
+            // }
+            if (SlotOptions.RandomizeElevatorPass)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.ElevatorPass>();
+            }
+            if (SlotOptions.RandomizeFocus)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.FocusSkill>();
+            }
+            if (SlotOptions.RandomizeSwim)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.SwimSkill>();
+            }
+            if (SlotOptions.SplitMothwingCloak)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.SplitCloak>();
+            }
+            if (SlotOptions.SplitMantisClaw)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.SplitClaw>();
+            }
+            if (SlotOptions.SplitCrystalHeart)
+            {
+                ItemChangerMod.Modules.Add<ItemChanger.Modules.SplitSuperdash>();
+            }
+
             if (SlotOptions.RandomCharmCosts != -1)
             {
                 RandomizeCharmCosts();

--- a/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
@@ -1,4 +1,5 @@
-﻿using ItemChanger;
+﻿using Archipelago.MultiClient.Net.Enums;
+using ItemChanger;
 using ItemChanger.Tags;
 using ItemChanger.UIDefs;
 

--- a/Archipelago.HollowKnight/SlotData/SlotOptions.cs
+++ b/Archipelago.HollowKnight/SlotData/SlotOptions.cs
@@ -174,5 +174,14 @@ namespace Archipelago.HollowKnight.SlotData
 
         [JsonProperty("StartingGeo")]
         public int StartingGeo { get; set; }
+
+        [JsonProperty("SplitMantisClaw")]
+        public bool SplitMantisClaw { get; set; }
+
+        [JsonProperty("SplitMothwingCloak")]
+        public bool SplitMothwingCloak { get; set; }
+
+        [JsonProperty("SplitCrystalHeart")]
+        public bool SplitCrystalHeart { get; set; }
     }
 }


### PR DESCRIPTION
This selectively adds a handful of ItemChanger modules during randomization time to properly support split items and other deviations from vanilla behavior.

While these modules needed for Cloak/Claw/Superdash, they're included for completeness.

They are required for Focus, Swim and Elevator Pass (unless the items are local, in which case they're automatically enabled)