### PR TITLE
Fixes being able to connect to the wrong slot

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -17,7 +17,6 @@ using ItemChanger.Items;
 using ItemChanger.Tags;
 using Modding;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace Archipelago.HollowKnight
 {
@@ -235,7 +234,7 @@ namespace Archipelago.HollowKnight
             {
                 LogDebug("StartOrResumeGame: Beginning first time randomization.");
                 ApSettings.ItemIndex = 0;
-                ApSettings.Seed = Convert.ToInt32((long)loginResult.SlotData["seed"]);
+                ApSettings.Seed = (long)loginResult.SlotData["seed"];
                 ApSettings.RoomSeed = session.RoomState.Seed;
 
                 LogDebug($"StartOrResumeGame: Room: {ApSettings.RoomSeed}; Seed = {ApSettings.RoomSeed}");
@@ -247,7 +246,7 @@ namespace Archipelago.HollowKnight
             else
             {
                 LogDebug($"StartOrResumeGame: Local : Room: {ApSettings.RoomSeed}; Seed = {ApSettings.Seed}");
-                var seed = Convert.ToInt32((long)loginResult.SlotData["seed"]);
+                var seed = (long)loginResult.SlotData["seed"];
                 LogDebug($"StartOrResumeGame: AP    : Room: {session.RoomState.Seed}; Seed = {seed}");
                 if (seed != ApSettings.Seed || session.RoomState.Seed != ApSettings.RoomSeed)
                 {

--- a/Archipelago.HollowKnight/ConnectionDetails.cs
+++ b/Archipelago.HollowKnight/ConnectionDetails.cs
@@ -7,5 +7,8 @@
         public string SlotName { get; set; }
         public string ServerPassword { get; set; }
         public int ItemIndex { get; set; }
+
+        public string RoomSeed { get; set; }
+        public int Seed { get; set; }
     }
 }

--- a/Archipelago.HollowKnight/ConnectionDetails.cs
+++ b/Archipelago.HollowKnight/ConnectionDetails.cs
@@ -9,6 +9,6 @@
         public int ItemIndex { get; set; }
 
         public string RoomSeed { get; set; }
-        public int Seed { get; set; }
+        public long Seed { get; set; }
     }
 }


### PR DESCRIPTION
Saves the AP seed and slot seed as part of ConnectionDetails, and validates it on reconnecting.

If validation fails, the user is kicked back to the main menu.  We ought to display an error message but this at least prevents accidentally sending a bunch of items to the wrong multiworld.

Closes #87 