### PR TITLE
Contains small adjustments to make CostSanity and other shop stuff work.

### DIFF
--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -134,10 +134,18 @@ namespace Archipelago.HollowKnight
 
             // Initialize shop locations in case they end up with zero items placed.
             AbstractLocation location;
-            foreach (string name in new string[] { "Sly", "Sly_(Key)", "Iselda", "Salubra", "Leg_Eater", "Grubfather", "Seer" })
+            AbstractPlacement pmt;
+            foreach (
+                    string name in new string[] {
+                        LocationNames.Sly, LocationNames.Sly_Key, LocationNames.Iselda, LocationNames.Salubra,
+                        LocationNames.Leg_Eater, LocationNames.Grubfather, LocationNames.Seer})
             {
                 location = Finder.GetLocation(name);
-                placements[location] = location.Wrap();
+                placements[location] = pmt = location.Wrap();
+                if(pmt is ShopPlacement shop)
+                {
+                    shop.defaultShopItems = DefaultShopItems.IseldaMapPins | DefaultShopItems.IseldaMapMarkers | DefaultShopItems.LegEaterRepair;
+                }
             }
 
             // Scout all locations

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -132,6 +132,15 @@ namespace Archipelago.HollowKnight
                 RandomizeCharmCosts();
             }
 
+            // Initialize shop locations in case they end up with zero items placed.
+            AbstractLocation location;
+            foreach (string name in new string[] { "Sly", "Sly_(Key)", "Iselda", "Salubra", "Leg_Eater", "Grubfather", "Seer" })
+            {
+                location = Finder.GetLocation(name);
+                placements[location] = location.Wrap();
+            }
+
+            // Scout all locations
             void ScoutCallback(LocationInfoPacket packet)
             {
                 MenuChanger.ThreadSupport.BeginInvoke(() =>
@@ -268,7 +277,7 @@ namespace Archipelago.HollowKnight
                         case "CHARMS":
                             costs.Add(new PDIntCost(
                                 entry.Value, nameof(PlayerData.charmsOwned),
-                                $"Acquire {entry.Value} total {((entry.Value == 1) ? "charm" : "charms")} to buy this item."
+                                $"Acquire {entry.Value} total {((entry.Value == 1) ? "charm" : "charms")}"
                             ));
                             break;
                         case "RANCIDEGGS":

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -138,13 +138,22 @@ namespace Archipelago.HollowKnight
             foreach (
                     string name in new string[] {
                         LocationNames.Sly, LocationNames.Sly_Key, LocationNames.Iselda, LocationNames.Salubra,
-                        LocationNames.Leg_Eater, LocationNames.Grubfather, LocationNames.Seer})
+                        LocationNames.Leg_Eater, LocationNames.Grubfather, LocationNames.Seer}
+            )
             {
                 location = Finder.GetLocation(name);
                 placements[location] = pmt = location.Wrap();
                 if(pmt is ShopPlacement shop)
                 {
                     shop.defaultShopItems = DefaultShopItems.IseldaMapPins | DefaultShopItems.IseldaMapMarkers | DefaultShopItems.LegEaterRepair;
+                }
+                else if(name == LocationNames.Grubfather)
+                {
+                    pmt.AddTag<DestroyGrubRewardTag>().destroyRewards = GrubfatherRewards.AllNonGeo;
+                }
+                else if (name == LocationNames.Seer)
+                {
+                    pmt.AddTag<DestroySeerRewardTag>().destroyRewards = SeerRewards.All;
                 }
             }
 
@@ -285,7 +294,7 @@ namespace Archipelago.HollowKnight
                         case "CHARMS":
                             costs.Add(new PDIntCost(
                                 entry.Value, nameof(PlayerData.charmsOwned),
-                                $"Acquire {entry.Value} total {((entry.Value == 1) ? "charm" : "charms")}"
+                                $"Acquire {entry.Value} {((entry.Value == 1) ? "charm" : "charms")}"
                             ));
                             break;
                         case "RANCIDEGGS":


### PR DESCRIPTION
- Ensure multiplacements always are created, so if a shop has zero items
  it still gets wrapped by IC rather than remaining at vanilla contents

- Shorten charm cost messaging so it reads better when combined with other
  costs.