### PR TITLE
Interop improvements for APMapMod.

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -33,12 +33,12 @@ namespace Archipelago.HollowKnight
         public SlotOptions SlotOptions { get; set; }
         public bool ArchipelagoEnabled { get; set; }
 
-        public int Slot => slot;
-        public string Player => session.Players.GetPlayerName(slot);
+        public int Slot { get; private set; }
+        public string Player => session.Players.GetPlayerName(Slot);
 
-        public static Sprite Sprite;
-        public static Sprite SmallSprite;
-        public static Sprite DeathLinkSprite;
+        public static Sprite Sprite { get; private set; }
+        public static Sprite SmallSprite { get; private set; }
+        public static Sprite DeathLinkSprite { get; private set; }
         internal static FieldInfo obtainStateFieldInfo;
 
         internal SpriteManager spriteManager;
@@ -49,7 +49,7 @@ namespace Archipelago.HollowKnight
         };
         internal ConnectionDetails ApSettings = new();
 
-        internal ArchipelagoSession session;
+        public ArchipelagoSession session { get; private set; }
 
         /// <summary>
         /// Allows lookup of a placement by its location ID number.  Used during syncing and shared-slot coop.
@@ -61,15 +61,14 @@ namespace Archipelago.HollowKnight
         /// </summary>
         private readonly HashSet<long> deferredLocationChecks = new();
 
-        public bool DeferringLocationChecks { get => deferringLocationChecks; }
-        private bool deferringLocationChecks = false;
+        public bool DeferringLocationChecks { get; private set; }
 
         private int pendingGeo = 0;
 
-        private int slot;
         private TimeSpan timeBetweenReceiveItem = TimeSpan.FromMilliseconds(500);
         private DateTime lastUpdate = DateTime.MinValue;
-        private Goal goal = null;
+        public Goal Goal { get; private set; } = null;
+        public bool GoalIsKnown { get; private set; } = false;  // Not Yet Implemented
 
         /// <summary>
         /// A preset GiveInfo structure that avoids creating geo and places messages in the corner.
@@ -178,7 +177,7 @@ namespace Archipelago.HollowKnight
 
         private void ModHooks_HeroUpdateHook()
         {
-            if (deferringLocationChecks)
+            if (DeferringLocationChecks)
             {
                 StopDeferringLocationChecks();
             }
@@ -210,10 +209,10 @@ namespace Archipelago.HollowKnight
             ModHooks.AfterPlayerDeadHook -= ModHooks_AfterPlayerDeadHook;
             On.HeroController.Start -= HeroController_Start;
 
-            if (goal != null)
+            if (Goal != null)
             {
-                goal.Unselect();
-                goal = null;
+                Goal.Unselect();
+                Goal = null;
             }
         }
 
@@ -269,7 +268,7 @@ namespace Archipelago.HollowKnight
             }
             try
             {
-                goal = Goal.GetGoal(SlotOptions.Goal);
+                Goal = Goal.GetGoal(SlotOptions.Goal);
             }
             catch (ArgumentOutOfRangeException ex)
             {
@@ -277,7 +276,7 @@ namespace Archipelago.HollowKnight
                 LogError($"Listed goal is {SlotOptions.Goal}, which is greater than {GoalsLookup.MAX}.  Is this an outdated client?");
                 throw ex;
             }
-            goal.Select();
+            Goal.Select();
 
             try
             {
@@ -303,7 +302,7 @@ namespace Archipelago.HollowKnight
             else if (loginResult is LoginSuccessful success)
             {
                 // Read slot data.
-                slot = success.Slot;
+                Slot = success.Slot;
                 SlotOptions = SlotDataExtract.ExtractObjectFromSlotData<SlotOptions>(success.SlotData["options"]);
                 LogDebug($"Deathlink type: {SlotOptions.DeathLink}");
 
@@ -375,7 +374,7 @@ namespace Archipelago.HollowKnight
                 }
                 else
                 {
-                    item.Give(pmt, deferringLocationChecks ? SilentGiveInfo : RemoteGiveInfo);
+                    item.Give(pmt, DeferringLocationChecks ? SilentGiveInfo : RemoteGiveInfo);
                 }
             }
 
@@ -391,7 +390,7 @@ namespace Archipelago.HollowKnight
             var name = session.Items.GetItemName(netItem.Item);
             LogDebug($"Receiving item ID {netItem.Item}.  Name is {name}.  Slot is {netItem.Player}.  Location is {netItem.Location}.");
 
-            if (netItem.Player == slot && netItem.Location > 0)
+            if (netItem.Player == Slot && netItem.Location > 0)
             {
                 MarkLocationAsChecked(netItem.Location);
                 return;
@@ -472,7 +471,7 @@ namespace Archipelago.HollowKnight
         public void DisconnectArchipelago()
         {
             DeathLinkSupport.Instance.Disable();
-            slot = 0;
+            Slot = 0;
 
             if (session?.Socket != null && session.Socket.Connected)
             {
@@ -492,7 +491,7 @@ namespace Archipelago.HollowKnight
         /// </remarks>
         public void DeferLocationChecks()
         {
-            deferringLocationChecks = true;
+            DeferringLocationChecks = true;
             LogDebug("Deferring location checks");
         }
 
@@ -502,7 +501,7 @@ namespace Archipelago.HollowKnight
         public void StopDeferringLocationChecks()
         {
             LogDebug("No longer deferring location checks");
-            deferringLocationChecks = false;
+            DeferringLocationChecks = false;
             if (deferredLocationChecks.Any())
             {
                 LogDebug($"Sending {deferredLocationChecks.Count} deferred location check(s).");
@@ -520,7 +519,7 @@ namespace Archipelago.HollowKnight
             {
                 throw new Exception("CheckLocation called with unspecified locationID.  This should never happen.");
             }
-            if(deferringLocationChecks)
+            if(DeferringLocationChecks)
             {
                 deferredLocationChecks.Add(locationID);
             }

--- a/Archipelago.HollowKnight/Enums.cs
+++ b/Archipelago.HollowKnight/Enums.cs
@@ -20,4 +20,12 @@ namespace Archipelago.HollowKnight
         Vanilla = 2,
         Shade = 3
     }
+
+    public enum WhitePalaceOption
+    {
+        Exclude = 0,
+        KingFragment = 1,
+        NoPathOfPain = 2,
+        Include = 3
+    }
 }

--- a/Archipelago.HollowKnight/SlotData/SlotOptions.cs
+++ b/Archipelago.HollowKnight/SlotData/SlotOptions.cs
@@ -176,6 +176,10 @@ namespace Archipelago.HollowKnight.SlotData
         [JsonConverter(typeof(StringEnumConverter))]
         public DeathLinkType DeathLink { get; set; }
 
+        // Even though this is encoded as an int, it doesn't import properly without doing this.
+        [JsonConverter(typeof(StringEnumConverter))]
+        public WhitePalaceOption WhitePalace { get; set; }
+
         [JsonProperty("StartingGeo")]
         public int StartingGeo { get; set; }
 


### PR DESCRIPTION
This changes several member variables to properties and exposes them to read-only access by outside callers, primarily for easing future integration with APMapMod.

Also cleaned up property usage some.