### PR TITLE
Improve automatic hinting of scouted locations.

### DIFF
--- a/Archipelago.HollowKnight/IC/ArchipelagoTags.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoTags.cs
@@ -138,7 +138,7 @@ namespace Archipelago.HollowKnight.IC
             // If we've been previewed but never told AP that, tell it now
             if (!Hinted && pmt.Visited.HasFlag(VisitState.Previewed))
             {
-                PlacementUtils.CreateLocationHint(pmt);
+                Archipelago.Instance.PendingPlacementHints.Add(pmt);
             }
         }
 
@@ -160,7 +160,7 @@ namespace Archipelago.HollowKnight.IC
             if (!Hinted && obj.NewFlags.HasFlag(VisitState.Previewed))
             {
                 // We are now previewed, but we weren't before.
-                PlacementUtils.CreateLocationHint(obj.Placement);
+                Archipelago.Instance.PendingPlacementHints.Add(obj.Placement);
             }
         }
     }

--- a/Archipelago.HollowKnight/IC/PlacementUtils.cs
+++ b/Archipelago.HollowKnight/IC/PlacementUtils.cs
@@ -24,48 +24,5 @@ namespace Archipelago.HollowKnight
                 }
             }
         }
-
-        internal static void CreateLocationHint(AbstractPlacement pmt)
-        {
-            if(pmt == null)
-            {
-                Archipelago.Instance.LogError("CreateLocationHint called for a NULL Placement!");
-                return;
-            }
-            // Trying to find out why this is dying.
-            ArchipelagoItemTag tag;
-            List<ArchipelagoItemTag> hintedTags = new();
-            List<long> hintedLocations = new();
-
-            // Find the location IDs associated with all of our placed items 
-            foreach (AbstractItem item in pmt.Items)
-            {
-                if (item.GetTag<ArchipelagoItemTag>(out tag) && !tag.Hinted)
-                { 
-                    tag.Hinted = true;
-                    hintedTags.Add(tag);
-                    hintedLocations.Add(tag.Location);
-                }
-            }
-            // Hint them if we found any.
-            if (hintedLocations.Any())
-            {
-                Archipelago.Instance.LogError($"Hinting {hintedLocations.Count()} locations.");
-
-                // Mark as hinted immediately, but later set the actual hinted status to match the sendPacketAsync result so it doesn't stay hinted if the connection is down.
-                try
-                {
-                    Archipelago.Instance.session.Socket.SendPacketAsync(new LocationScoutsPacket()
-                    {
-                        CreateAsHint = true,
-                        Locations = hintedLocations.ToArray(),
-                    }, (result) => { foreach (ArchipelagoItemTag tag in hintedTags) { tag.Hinted = result; } });
-                }
-                catch (ArchipelagoSocketClosedException)
-                {
-                    Archipelago.Instance.ReportDisconnect();
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
 - Defer all hinting until leaving the scene
 - Do not hint items that are not flagged Advancement or NeverExclude
 - Do not hint already obtained items
 - Do not hint items that have item previews disabled in IC