### PR TITLE
Fix Wrong Seed Connections Pt.2

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -277,6 +277,7 @@ namespace Archipelago.HollowKnight
                 LogDebug($"StartOrResumeGame: AP    : Room: {session.RoomState.Seed}; Seed = {seed}");
                 if (seed != ApSettings.Seed || session.RoomState.Seed != ApSettings.RoomSeed)
                 {
+                    DisconnectArchipelago();
                     UIManager.instance.UIReturnToMainMenu();
                     throw new ArchipelagoConnectionException("Slot mismatch.  Saved seed does not match the server value.  Is this the correct save?");
                 }


### PR DESCRIPTION
When kicking users back to the main menu due to a seed mismatch, disconnect from AP first.  This prevents prior checks from being erroneously sent out.

This implementation will scream into the modlog a fair amount currently since assorted places in code don't expect `session` to go null.  That warrants a better fix longterm, but I don't want to disrupt that implementation so close to 0.1.0 release.

Closes #109