### PR TITLE
Use fallback item names if Multiclient fails to give us one for some reason

### DIFF
--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -147,7 +147,7 @@ namespace Archipelago.HollowKnight
                     foreach (var item in packet.Locations)
                     {
                         var locationName = session.Locations.GetLocationNameFromId(item.Location);
-                        var itemName = session.Items.GetItemName(item.Item);
+                        var itemName = session.Items.GetItemName(item.Item) ?? $"?Item {item.Item}?";
 
                         PlaceItem(locationName, itemName, item);
                     }


### PR DESCRIPTION
This fixes the issue Snow had in Discord earlier due to a corrupt datapackage.