### PR TITLE
Fix World Sense and Focus locations breaking their lore tablets.

### DIFF
--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -210,18 +210,24 @@ namespace Archipelago.HollowKnight
             // But we can have multiple placements at the same location, so do this workaround.  (Rando4 does something similar per its README)
             if (SlotOptions.RandomizeLoreTablets)
             {
-                if (location == "Focus" || location == "World_Sense")
+                switch (location)
                 {
-                    location = $"Lore_Tablet-{location}";
+                    case LocationNames.Focus:
+                        location = LocationNames.Lore_Tablet_Kings_Pass_Focus;
+                        break;
+                    case LocationNames.World_Sense:
+                        location = LocationNames.Lore_Tablet_World_Sense;
+                        break;
+                    // no default
                 }
             }
-            else if (location == "Lore_Tablet-World_Sense")
+            else if (location == LocationNames.Lore_Tablet_World_Sense)
             {
-                location = "World_Sense";
+                location = LocationNames.World_Sense;
             }
-            else if (SlotOptions.RandomizeFocus && location == "Lore_Tablet-Focus")
+            else if (SlotOptions.RandomizeFocus && location == LocationNames.Lore_Tablet_Kings_Pass_Focus)
             {
-                location = "Focus";
+                location = LocationNames.Focus;
             }
 
             AbstractLocation loc = Finder.GetLocation(location);

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -206,6 +206,23 @@ namespace Archipelago.HollowKnight
 
             var originalLocation = string.Copy(location);
             location = StripShopSuffix(location);
+            // IC does not like placements at these locations if there's also a location at the lore tablet, it renders the lore tablet inoperable.
+            // But we can have multiple placements at the same location, so do this workaround.  (Rando4 does something similar per its README)
+            if (SlotOptions.RandomizeLoreTablets)
+            {
+                if (location == "Focus" || location == "World_Sense")
+                {
+                    location = $"Lore_Tablet-{location}";
+                }
+            }
+            else if (location == "Lore_Tablet-World_Sense")
+            {
+                location = "World_Sense";
+            }
+            else if (SlotOptions.RandomizeFocus && location == "Lore_Tablet-Focus")
+            {
+                location = "Focus";
+            }
 
             AbstractLocation loc = Finder.GetLocation(location);
             if (loc == null)


### PR DESCRIPTION
Per homothety: "World_Sense and Lore_Tablet-World_Sense are incompatible locations (likewise, Focus, and Lore_Tablet-Focus are incompatible)."

Rando4 works around it similarly per their README.