### PR TITLE
When loading an ArchipelagoItem, reload our UIDef's sprite.

### DIFF
--- a/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
+++ b/Archipelago.HollowKnight/IC/ArchipelagoItem.cs
@@ -52,5 +52,14 @@ namespace Archipelago.HollowKnight.IC
                 sprite = new BoxedSprite(Archipelago.SmallSprite)
             };
         }
+
+        protected override void OnLoad()
+        {
+            base.OnLoad();
+            if(UIDef is ArchipelagoUIDef def)
+            {
+                def.sprite = new BoxedSprite(Archipelago.SmallSprite);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes non-HK items losing their sprites when loading an existing save.  Closes #80 