### PR TITLE
Update Archipelago .net client to version 4.0

### DIFF
--- a/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
+++ b/Archipelago.HollowKnight/Archipelago.HollowKnight.csproj
@@ -52,7 +52,7 @@
     <EmbeddedResource Include="Resources\DeathLinkIcon.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Archipelago.MultiClient.Net" Version="3.1.0" />
+    <PackageReference Include="Archipelago.MultiClient.Net" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/Archipelago.HollowKnight/Archipelago.cs
+++ b/Archipelago.HollowKnight/Archipelago.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Archipelago.HollowKnight.IC;
@@ -205,7 +204,7 @@ namespace Archipelago.HollowKnight
         public void EndGame()
         {
             LogDebug("Ending Archipelago game");
-            SendPlacementHints().Wait();
+            SendPlacementHints();
             try
             {
                 OnArchipelagoGameEnded?.Invoke();
@@ -314,7 +313,7 @@ namespace Archipelago.HollowKnight
 
         private void Events_OnSceneChange(UnityEngine.SceneManagement.Scene obj)
         {
-            SendPlacementHints().Wait();
+            SendPlacementHints();
         }
 
         private void Socket_SocketClosed(string reason)

--- a/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
+++ b/Archipelago.HollowKnight/ArchipelagoRandomizer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
 using System.Threading.Tasks;
 using Archipelago.HollowKnight.IC;
 using Archipelago.HollowKnight.Placements;
@@ -94,7 +93,6 @@ namespace Archipelago.HollowKnight
 
         public void Randomize()
         {
-            Instance.LogDebug($"Starting Randomize.");
             var session = Session;
             ItemChangerMod.CreateSettingsProfile();
             // Add IC modules as needed
@@ -105,8 +103,6 @@ namespace Archipelago.HollowKnight
             // }
 
             AddItemChangerModules();
-
-            Instance.LogDebug($"Item Changer Modules Added");
 
             if (SlotOptions.RandomCharmCosts != -1)
             {
@@ -144,15 +140,11 @@ namespace Archipelago.HollowKnight
                 }
             }
 
-            Instance.LogDebug($"About to scout locations");
-
             // Scout all locations
             var locations = new List<long>(session.Locations.AllLocations);
             Task<LocationInfoPacket> packetTask = session.Locations.ScoutLocationsAsync(locations.ToArray());
 
             LocationInfoPacket packet = packetTask.Result;
-
-            Instance.LogDebug($"locations scouted, invoking menu thread support");
 
             MenuChanger.ThreadSupport.BeginInvoke(() =>
             {
@@ -165,8 +157,6 @@ namespace Archipelago.HollowKnight
                 }
                 ItemChangerMod.AddPlacements(placements.Values);
             });
-
-            Instance.LogDebug($"Completed randomization");
         }
 
         private void AddItemChangerModules()

--- a/Archipelago.HollowKnight/DeathLinkSupport.cs
+++ b/Archipelago.HollowKnight/DeathLinkSupport.cs
@@ -164,7 +164,8 @@ namespace Archipelago.HollowKnight
             Reset();
 
             ap.LogDebug($"Enabling DeathLink support, type: {mode}");
-            service = ap.session.CreateDeathLinkServiceAndEnable();
+            service = ap.session.CreateDeathLinkService();
+            service.EnableDeathLink();
             service.OnDeathLinkReceived += OnDeathLinkReceived;
             ModHooks.HeroUpdateHook += ModHooks_HeroUpdateHook;
             On.HeroController.TakeDamage += HeroController_TakeDamage;

--- a/Archipelago.HollowKnight/MC/ArchipelagoModeMenuConstructor.cs
+++ b/Archipelago.HollowKnight/MC/ArchipelagoModeMenuConstructor.cs
@@ -80,7 +80,6 @@ namespace Archipelago.HollowKnight.MC
             Archipelago.Instance.ApSettings = Archipelago.Instance.MenuSettings with { };  // Clone MenuSettings into ApSettings
             try
             {
-                // Archipelago.Instance.ConnectAndRandomize();
                 Archipelago.Instance.StartOrResumeGame(true);
                 MenuChangerMod.HideAllMenuPages();
                 UIManager.instance.StartNewGame();
@@ -95,7 +94,6 @@ namespace Archipelago.HollowKnight.MC
                 Archipelago.Instance.LogError(ex);
                 Archipelago.Instance.DisconnectArchipelago();
             }
-
         }
 
         public override void OnExitMainMenu()


### PR DESCRIPTION
Primarily updated the mod to use the new Archipelago.MultiClient.Net version.  Much of the code remains in place, but a few minor changes have been made.

- CheckLocation now kicks off a separate task to send the packet to the Archipelago session.  This fixes a small hitch that would occur when collecting items.
- `ScoutCallback` logic moved around so it isn't a callback anymore.
- `SendPlacementHints` slightly modified.  May want to revisit the async/await logic here, but this seems to work for now.

Much of this is barely tested, and will need some full playthroughs be to confident for release.